### PR TITLE
Bump node from deprecated and unsupported v12 to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ inputs:
     required: false
     default: './'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
This resolves the following warning emitted for any CI workflow using this action:

> ### ⚠️ Check License Compliance
>
> The following actions uses node12 which is deprecated and will be forced to run on node16: daynin/nodejs-license-checker@v0.2.0.
>
> For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

Would be great if you could publish a fix with this. 🙏 